### PR TITLE
feat(telescope): add recursive git detection for file search

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -91,7 +91,7 @@ vim.keymap.set("n", "<leader>gp", require("gitsigns").preview_hunk)
 vim.keymap.set("n", "<leader>sr", require("telescope.builtin").resume)
 vim.keymap.set("n", "<leader>sg", require("telescope.builtin").live_grep)
 vim.keymap.set("n", "<leader>sf", function()
-    if vim.uv.fs_stat(".git") then
+    if vim.fs.find(".git", { upward = true, type = "directory" })[1] ~= nil then
         require("telescope.builtin").git_files({ show_untracked = true })
     else
         require("telescope.builtin").find_files()


### PR DESCRIPTION
Previously, `fs_stat` would only find git files if in root of project.
- Replace `fs_stat` with `fs_find` for upward directory search
- Enables git files from any subdirectory within repo

Reject this if the suggested workflow is not desired as `fs_stat` is faster. 